### PR TITLE
fix: oidc npmjs config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,7 @@
 name: Release
 
 permissions:
-  contents: write
-  id-token: write # to enable use of OIDC for npm provenance
-  issues: write # to be able to comment on released issues
-  pull-requests: write # to be able to comment on released pull requests
+  contents: read # for checkout
 
 on:
   push:
@@ -20,6 +17,11 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      issues: write
+      pull-requests: write
 
     steps:
       - name: Checkout repository
@@ -28,7 +30,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version: '24'
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4.1.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Workflow-only changes; main risk is CI/release breakage due to updated Node version or mis-scoped permissions.
> 
> **Overview**
> Updates the GitHub Actions `Release` workflow to use least-privilege permissions: default workflow `contents` is reduced to read-only for checkout, while the `release` job explicitly grants write permissions plus `id-token` for OIDC/npm provenance.
> 
> Bumps the release pipeline Node.js version from `22` to `24`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b37d4e5576e541ac9b51652d07ad9a8429fc987d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->