### PR TITLE
Add rate limiting support to parallel transform

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,50 @@ The elapsed time is around 1 second because it processed 10 items concurrently
 and the slowest took 1 second to be processed. Moreover the order of the items
 in the result array is equal to the input one.
 
+### Rate-limited ParallelTransform
+
+Usage example:
+[Rate-limited Parallel Transform](src/examples/rate-limited-parallel-transform.ts)
+
+```bash
+npx tsx src/examples/rate-limited-parallel-transform.ts
+```
+
+Running this example will output something similar to this:
+
+```
+Elapsed time: 3119.824332ms
+Result: [
+  1, 2, 3, 4,  5,
+  6, 7, 8, 9, 10
+]
+```
+
+The elapsed time is around 3 seconds because the rate limiter allows only 3
+items per 1-second window. With 10 items and each taking 100ms to process, the
+throughput is gate-kept by the rate limit rather than the concurrency limit.
+
+### Rate-limited OrderedParallelTransform
+
+Usage example:
+[Rate-limited Ordered Parallel Transform](src/examples/rate-limited-ordered-parallel-transform.ts)
+
+```bash
+npx tsx src/examples/rate-limited-ordered-parallel-transform.ts
+```
+
+Running this example will output something similar to this:
+
+```
+Elapsed time: 3118.652241ms
+Result: [
+  1, 2, 3, 4,  5,
+  6, 7, 8, 9, 10
+]
+```
+
+Same as above but the output order matches the input order.
+
 ### ParallelTransformFactory
 
 Usage example:

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "prepare": "husky",
     "test": "node --import tsx --test-reporter=spec --test './src/**/*.spec.ts' './src/*.spec.ts'",
     "test:coverage": "c8 node --import tsx --test-reporter=spec --test './src/**/*.spec.ts' './src/*.spec.ts'",
-    "test:debug": "node --inspect-wait --import tsx --test './src/**/*.spec.ts' './src/*.spec.ts'"
+    "test:debug": "node --inspect-wait --import tsx --test './src/**/*.spec.ts' './src/*.spec.ts'",
+    "test:watch": "node --import tsx --test-reporter=spec --watch --test './src/**/*.spec.ts' './src/*.spec.ts'"
   },
   "devDependencies": {
     "@commitlint/cli": "20.5.0",

--- a/src/examples/rate-limited-ordered-parallel-transform.ts
+++ b/src/examples/rate-limited-ordered-parallel-transform.ts
@@ -1,0 +1,31 @@
+import { hrtime } from 'node:process';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { inspect } from 'node:util';
+
+import { OrderedParallelTransform } from '../ordered-parallel-transform.js';
+
+import { collect } from './../utils/stream/collect.js';
+
+const result: never[] = [];
+const start = hrtime.bigint();
+await pipeline(
+  Readable.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+  new OrderedParallelTransform({
+    transform: (chunk, _, done) => {
+      setTimeout(() => {
+        done(null, chunk);
+      }, 100);
+    },
+    objectMode: true,
+    rateLimit: {
+      maxPerWindow: 3,
+      windowMs: 1_000,
+    },
+  }),
+  collect(result),
+);
+const end = hrtime.bigint();
+
+console.log(`Elapsed time: ${Number(end - start) / 1e6}ms`);
+console.log(`Result: ${inspect(result, { depth: null })}`);

--- a/src/examples/rate-limited-parallel-transform.ts
+++ b/src/examples/rate-limited-parallel-transform.ts
@@ -1,0 +1,30 @@
+import { hrtime } from 'node:process';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { inspect } from 'node:util';
+
+import { ParallelTransform } from './../parallel-transform.js';
+import { collect } from './../utils/stream/collect.js';
+
+const result: never[] = [];
+const start = hrtime.bigint();
+await pipeline(
+  Readable.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+  new ParallelTransform({
+    transform: (chunk, _, done) => {
+      setTimeout(() => {
+        done(null, chunk);
+      }, 100);
+    },
+    objectMode: true,
+    rateLimit: {
+      maxPerWindow: 3,
+      windowMs: 1_000,
+    },
+  }),
+  collect(result),
+);
+const end = hrtime.bigint();
+
+console.log(`Elapsed time: ${Number(end - start) / 1e6}ms`);
+console.log(`Result: ${inspect(result, { depth: null })}`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export {
   ParallelTransform,
   type ParallelTransformOptions,
 } from './parallel-transform.js';
+export { type RateLimitOptions } from './rate-limiter.js';
 export {
   parallelTransform,
   promisifiedParallelTransform,

--- a/src/ordered-parallel-transform.spec.ts
+++ b/src/ordered-parallel-transform.spec.ts
@@ -8,16 +8,70 @@ import { AsyncIdentity } from './utils/async-identity.js';
 import { eventsSimulation } from './utils/events-simulation.js';
 import { collect } from './utils/stream/collect.js';
 
+describe('Given OrderedParallelTransform with ratePerSecond', () => {
+  it('should limit transform calls per second and preserve input order', async context => {
+    context.mock.timers.enable({ apis: ['setInterval'] });
+    const callTimestamps: number[] = [];
+    let currentTime = 0;
+    const result: number[] = [];
+
+    const pipelinePromise = pipeline(
+      Readable.from([1, 2, 3, 4]),
+      new OrderedParallelTransform({
+        objectMode: true,
+        ratePerSecond: 2,
+        transform: (
+          chunk: number,
+          _: BufferEncoding,
+          done: TransformCallback,
+        ) => {
+          callTimestamps.push(currentTime);
+          done(null, chunk);
+        },
+      }),
+      collect(result),
+    );
+
+    // First 2 should fire immediately (window 0)
+    await new Promise(r => process.nextTick(r));
+    equal(callTimestamps.length, 2);
+
+    // Tick the interval to release the next window
+    currentTime = 1000;
+    context.mock.timers.tick(1000);
+    await new Promise(r => process.nextTick(r));
+
+    await pipelinePromise;
+    deepEqual(callTimestamps, [0, 0, 1000, 1000]);
+    // Order should be preserved
+    deepEqual(result, [1, 2, 3, 4]);
+  });
+});
+
 describe('Given OrderedParallelTransform', () => {
   describe('When creating a new instance in a synchronous pipeline of objects', () => {
     describe('When no error occurs in the transform or flush function', () => {
-      const testCases = [
+      const testCases: {
+        description: string;
+        input: number[];
+        transform: (
+          chunk: number,
+          _: BufferEncoding,
+          done: TransformCallback,
+        ) => void;
+        expected: {
+          result: number[];
+          transform: {
+            callCount: number;
+          };
+        };
+      }[] = [
         {
           description:
             'When input is an empty array, it should return an empty array',
           input: [],
           transform: (
-            chunk: never,
+            chunk: number,
             _: BufferEncoding,
             done: TransformCallback,
           ) => {
@@ -71,7 +125,14 @@ describe('Given OrderedParallelTransform', () => {
       for (const { input, expected, description, transform } of testCases) {
         it(description, async context => {
           const result: never[] = [];
-          const transformMock = context.mock.fn(transform);
+          const transformMock =
+            context.mock.fn<
+              (
+                chunk: number,
+                _: BufferEncoding,
+                done: TransformCallback,
+              ) => void
+            >(transform);
           const flushMock = context.mock.fn((done: TransformCallback) =>
             done(),
           );

--- a/src/ordered-parallel-transform.spec.ts
+++ b/src/ordered-parallel-transform.spec.ts
@@ -8,8 +8,8 @@ import { AsyncIdentity } from './utils/async-identity.js';
 import { eventsSimulation } from './utils/events-simulation.js';
 import { collect } from './utils/stream/collect.js';
 
-describe('Given OrderedParallelTransform with ratePerSecond', () => {
-  it('should limit transform calls per second and preserve input order', async context => {
+describe('Given OrderedParallelTransform with rateLimit', () => {
+  it('should limit transform calls per window and preserve input order', async context => {
     context.mock.timers.enable({ apis: ['setInterval'] });
     const callTimestamps: number[] = [];
     let currentTime = 0;
@@ -19,7 +19,7 @@ describe('Given OrderedParallelTransform with ratePerSecond', () => {
       Readable.from([1, 2, 3, 4]),
       new OrderedParallelTransform({
         objectMode: true,
-        ratePerSecond: 2,
+        rateLimit: { maxPerWindow: 2 },
         transform: (
           chunk: number,
           _: BufferEncoding,
@@ -159,7 +159,7 @@ describe('Given OrderedParallelTransform', () => {
             'When input is an empty array, it should return an empty array since the transform function is never called',
           input: [],
           transform: (
-            chunk: never,
+            chunk: number,
             _: BufferEncoding,
             done: TransformCallback,
           ) => {
@@ -528,7 +528,7 @@ describe('Given OrderedParallelTransform', () => {
             objectMode: true,
             maxConcurrency,
             transform: (
-              chunk: never,
+              chunk: number,
               bufferEncoding: BufferEncoding,
               done: TransformCallback,
             ) => {

--- a/src/ordered-parallel-transform.ts
+++ b/src/ordered-parallel-transform.ts
@@ -33,7 +33,7 @@ export class OrderedParallelTransform extends ParallelTransform {
     const resultContainer = resultContainerFactory.create();
     this.resultsQueue.enqueue(resultContainer);
     return (error?: Error | null, data?: never): void => {
-      this.running--;
+      this.inflight--;
       if (error) {
         this.emit('error', error);
         return;
@@ -49,7 +49,7 @@ export class OrderedParallelTransform extends ParallelTransform {
         this.callbacks.transform = undefined;
         done();
       }
-      if (this.running === 0 && this.callbacks.flush) {
+      if (this.inflight === 0 && this.callbacks.flush) {
         this.user.flush.call(
           this,
           this.onUserFlushComplete(this.callbacks.flush),

--- a/src/parallel-transform.factory.spec.ts
+++ b/src/parallel-transform.factory.spec.ts
@@ -22,7 +22,7 @@ describe('Given parallelTransform factory', () => {
       });
       ok(transform instanceof ParallelTransform);
       equal(transform.maxConcurrency, 16);
-      equal(transform.ratePerSecond, undefined);
+      equal(transform.rateLimit, undefined);
       await pipeline(Readable.from([1, 2, 3]), transform, collect(result));
       deepEqual(result, [2, 4, 6]);
     });
@@ -38,26 +38,26 @@ describe('Given parallelTransform factory', () => {
       });
       ok(transform instanceof OrderedParallelTransform);
       equal(transform.maxConcurrency, 16);
-      equal(transform.ratePerSecond, undefined);
+      equal(transform.rateLimit, undefined);
       await pipeline(Readable.from([1, 2, 3]), transform, collect(result));
       deepEqual(result, [2, 4, 6]);
     });
   });
 });
 
-describe('Given parallelTransform factory with ratePerSecond', () => {
+describe('Given parallelTransform factory with rateLimit', () => {
   describe('When ordered is false', () => {
     it('should create a ParallelTransform with rate limiting', async () => {
       const result: number[] = [];
       const transform = parallelTransform({
         objectMode: true,
         ordered: false,
-        ratePerSecond: 10,
+        rateLimit: { maxPerWindow: 10 },
         transform: (chunk: number, _, callback) => callback(null, chunk * 2),
       });
       ok(transform instanceof ParallelTransform);
       equal(transform.maxConcurrency, 16);
-      equal(transform.ratePerSecond, 10);
+      deepEqual(transform.rateLimit, { maxPerWindow: 10, windowMs: 1_000 });
       await pipeline(Readable.from([1, 2, 3]), transform, collect(result));
       deepEqual(result, [2, 4, 6]);
     });
@@ -69,29 +69,29 @@ describe('Given parallelTransform factory with ratePerSecond', () => {
       const transform = parallelTransform({
         objectMode: true,
         ordered: true,
-        ratePerSecond: 10,
+        rateLimit: { maxPerWindow: 10 },
         transform: (chunk: number, _, callback) => callback(null, chunk * 2),
       });
       ok(transform instanceof OrderedParallelTransform);
       equal(transform.maxConcurrency, 16);
-      equal(transform.ratePerSecond, 10);
+      deepEqual(transform.rateLimit, { maxPerWindow: 10, windowMs: 1_000 });
       await pipeline(Readable.from([1, 2, 3]), transform, collect(result));
       deepEqual(result, [2, 4, 6]);
     });
   });
 });
 
-describe('Given promisifiedParallelTransform factory with ratePerSecond', () => {
-  it('should pass ratePerSecond through to the transform', async () => {
+describe('Given promisifiedParallelTransform factory with rateLimit', () => {
+  it('should pass rateLimit through to the transform', async () => {
     const result: number[] = [];
     const transform = promisifiedParallelTransform<number, number>({
       objectMode: true,
       ordered: false,
-      ratePerSecond: 10,
+      rateLimit: { maxPerWindow: 10 },
       transform: (chunk: number) => chunk * 2,
     });
     equal(transform.maxConcurrency, 16);
-    equal(transform.ratePerSecond, 10);
+    deepEqual(transform.rateLimit, { maxPerWindow: 10, windowMs: 1_000 });
     await pipeline(Readable.from([1, 2, 3]), transform, collect(result));
     deepEqual(result, [2, 4, 6]);
   });

--- a/src/parallel-transform.factory.spec.ts
+++ b/src/parallel-transform.factory.spec.ts
@@ -1,4 +1,4 @@
-import { deepEqual, ok } from 'node:assert/strict';
+import { deepEqual, equal, ok } from 'node:assert/strict';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { describe, it } from 'node:test';
@@ -21,6 +21,8 @@ describe('Given parallelTransform factory', () => {
         transform: (chunk: number, _, callback) => callback(null, chunk * 2),
       });
       ok(transform instanceof ParallelTransform);
+      equal(transform.maxConcurrency, 16);
+      equal(transform.ratePerSecond, undefined);
       await pipeline(Readable.from([1, 2, 3]), transform, collect(result));
       deepEqual(result, [2, 4, 6]);
     });
@@ -35,9 +37,63 @@ describe('Given parallelTransform factory', () => {
         transform: (chunk: number, _, callback) => callback(null, chunk * 2),
       });
       ok(transform instanceof OrderedParallelTransform);
+      equal(transform.maxConcurrency, 16);
+      equal(transform.ratePerSecond, undefined);
       await pipeline(Readable.from([1, 2, 3]), transform, collect(result));
       deepEqual(result, [2, 4, 6]);
     });
+  });
+});
+
+describe('Given parallelTransform factory with ratePerSecond', () => {
+  describe('When ordered is false', () => {
+    it('should create a ParallelTransform with rate limiting', async () => {
+      const result: number[] = [];
+      const transform = parallelTransform({
+        objectMode: true,
+        ordered: false,
+        ratePerSecond: 10,
+        transform: (chunk: number, _, callback) => callback(null, chunk * 2),
+      });
+      ok(transform instanceof ParallelTransform);
+      equal(transform.maxConcurrency, 16);
+      equal(transform.ratePerSecond, 10);
+      await pipeline(Readable.from([1, 2, 3]), transform, collect(result));
+      deepEqual(result, [2, 4, 6]);
+    });
+  });
+
+  describe('When ordered is true', () => {
+    it('should create an OrderedParallelTransform with rate limiting', async () => {
+      const result: number[] = [];
+      const transform = parallelTransform({
+        objectMode: true,
+        ordered: true,
+        ratePerSecond: 10,
+        transform: (chunk: number, _, callback) => callback(null, chunk * 2),
+      });
+      ok(transform instanceof OrderedParallelTransform);
+      equal(transform.maxConcurrency, 16);
+      equal(transform.ratePerSecond, 10);
+      await pipeline(Readable.from([1, 2, 3]), transform, collect(result));
+      deepEqual(result, [2, 4, 6]);
+    });
+  });
+});
+
+describe('Given promisifiedParallelTransform factory with ratePerSecond', () => {
+  it('should pass ratePerSecond through to the transform', async () => {
+    const result: number[] = [];
+    const transform = promisifiedParallelTransform<number, number>({
+      objectMode: true,
+      ordered: false,
+      ratePerSecond: 10,
+      transform: (chunk: number) => chunk * 2,
+    });
+    equal(transform.maxConcurrency, 16);
+    equal(transform.ratePerSecond, 10);
+    await pipeline(Readable.from([1, 2, 3]), transform, collect(result));
+    deepEqual(result, [2, 4, 6]);
   });
 });
 

--- a/src/parallel-transform.spec.ts
+++ b/src/parallel-transform.spec.ts
@@ -8,8 +8,8 @@ import { AsyncIdentity } from './utils/async-identity.js';
 import { eventsSimulation } from './utils/events-simulation.js';
 import { collect } from './utils/stream/collect.js';
 
-describe('Given ParallelTransform with ratePerSecond', () => {
-  it('should limit the number of transform calls per second', async context => {
+describe('Given ParallelTransform with rateLimit', () => {
+  it('should limit the number of transform calls per window', async context => {
     context.mock.timers.enable({ apis: ['setInterval'] });
     const callTimestamps: number[] = [];
     let currentTime = 0;
@@ -19,7 +19,7 @@ describe('Given ParallelTransform with ratePerSecond', () => {
       Readable.from([1, 2, 3, 4]),
       new ParallelTransform({
         objectMode: true,
-        ratePerSecond: 2,
+        rateLimit: { maxPerWindow: 2 },
         transform: (
           chunk: number,
           _: BufferEncoding,
@@ -46,7 +46,7 @@ describe('Given ParallelTransform with ratePerSecond', () => {
     deepEqual(result, [1, 2, 3, 4]);
   });
 
-  it('should apply both maxConcurrency and ratePerSecond together', async context => {
+  it('should apply both maxConcurrency and rateLimit together', async context => {
     context.mock.timers.enable({ apis: ['setInterval'] });
     const callTimestamps: number[] = [];
     let currentTime = 0;
@@ -57,7 +57,7 @@ describe('Given ParallelTransform with ratePerSecond', () => {
       new ParallelTransform({
         objectMode: true,
         maxConcurrency: 3,
-        ratePerSecond: 2,
+        rateLimit: { maxPerWindow: 2 },
         transform: (
           chunk: number,
           _: BufferEncoding,
@@ -70,7 +70,7 @@ describe('Given ParallelTransform with ratePerSecond', () => {
       collect(result),
     );
 
-    // ratePerSecond=2 limits to 2 per window despite maxConcurrency=3
+    // rateLimit.max=2 limits to 2 per window despite maxConcurrency=3
     await new Promise(r => process.nextTick(r));
     equal(callTimestamps.length, 2);
 

--- a/src/parallel-transform.spec.ts
+++ b/src/parallel-transform.spec.ts
@@ -88,6 +88,54 @@ describe('Given ParallelTransform with rateLimit', () => {
   });
 });
 
+describe('Given ParallelTransform _destroy', () => {
+  it('should call super._destroy and emit close event', async () => {
+    const stream = new ParallelTransform({
+      objectMode: true,
+      transform: (
+        chunk: number,
+        _: BufferEncoding,
+        done: TransformCallback,
+      ) => {
+        done(null, chunk);
+      },
+    });
+
+    const closePromise = new Promise<void>(resolve => {
+      stream.on('close', resolve);
+    });
+
+    stream.destroy();
+    await closePromise;
+
+    ok(stream.destroyed, 'stream should be marked as destroyed');
+  });
+
+  it('should propagate the error through super._destroy', async () => {
+    const stream = new ParallelTransform({
+      objectMode: true,
+      transform: (
+        chunk: number,
+        _: BufferEncoding,
+        done: TransformCallback,
+      ) => {
+        done(null, chunk);
+      },
+    });
+
+    const destroyError = new Error('test-destroy-error');
+    const errorPromise = new Promise<Error>(resolve => {
+      stream.on('error', resolve);
+    });
+
+    stream.destroy(destroyError);
+    const emittedError = await errorPromise;
+
+    equal(emittedError, destroyError);
+    ok(stream.destroyed, 'stream should be marked as destroyed');
+  });
+});
+
 describe('Given ParallelTransform', () => {
   it('should initiate the user transform before signaling readiness for the next chunk', async () => {
     const order: string[] = [];

--- a/src/parallel-transform.spec.ts
+++ b/src/parallel-transform.spec.ts
@@ -8,7 +8,129 @@ import { AsyncIdentity } from './utils/async-identity.js';
 import { eventsSimulation } from './utils/events-simulation.js';
 import { collect } from './utils/stream/collect.js';
 
+describe('Given ParallelTransform with ratePerSecond', () => {
+  it('should limit the number of transform calls per second', async context => {
+    context.mock.timers.enable({ apis: ['setInterval'] });
+    const callTimestamps: number[] = [];
+    let currentTime = 0;
+    const result: number[] = [];
+
+    const pipelinePromise = pipeline(
+      Readable.from([1, 2, 3, 4]),
+      new ParallelTransform({
+        objectMode: true,
+        ratePerSecond: 2,
+        transform: (
+          chunk: number,
+          _: BufferEncoding,
+          done: TransformCallback,
+        ) => {
+          callTimestamps.push(currentTime);
+          done(null, chunk);
+        },
+      }),
+      collect(result),
+    );
+
+    // First 2 should fire immediately (window 0)
+    await new Promise(r => process.nextTick(r));
+    equal(callTimestamps.length, 2);
+
+    // Tick the interval to release the next window
+    currentTime = 1000;
+    context.mock.timers.tick(1000);
+    await new Promise(r => process.nextTick(r));
+
+    await pipelinePromise;
+    deepEqual(callTimestamps, [0, 0, 1000, 1000]);
+    deepEqual(result, [1, 2, 3, 4]);
+  });
+
+  it('should apply both maxConcurrency and ratePerSecond together', async context => {
+    context.mock.timers.enable({ apis: ['setInterval'] });
+    const callTimestamps: number[] = [];
+    let currentTime = 0;
+    const result: number[] = [];
+
+    const pipelinePromise = pipeline(
+      Readable.from([1, 2, 3, 4, 5, 6]),
+      new ParallelTransform({
+        objectMode: true,
+        maxConcurrency: 3,
+        ratePerSecond: 2,
+        transform: (
+          chunk: number,
+          _: BufferEncoding,
+          done: TransformCallback,
+        ) => {
+          callTimestamps.push(currentTime);
+          done(null, chunk);
+        },
+      }),
+      collect(result),
+    );
+
+    // ratePerSecond=2 limits to 2 per window despite maxConcurrency=3
+    await new Promise(r => process.nextTick(r));
+    equal(callTimestamps.length, 2);
+
+    currentTime = 1000;
+    context.mock.timers.tick(1000);
+    await new Promise(r => process.nextTick(r));
+
+    currentTime = 2000;
+    context.mock.timers.tick(1000);
+    await new Promise(r => process.nextTick(r));
+
+    await pipelinePromise;
+    deepEqual(callTimestamps, [0, 0, 1000, 1000, 2000, 2000]);
+    deepEqual(result.sort(), [1, 2, 3, 4, 5, 6]);
+  });
+});
+
 describe('Given ParallelTransform', () => {
+  it('should initiate the user transform before signaling readiness for the next chunk', async () => {
+    const order: string[] = [];
+    const result: number[] = [];
+
+    class InstrumentedParallelTransform extends ParallelTransform {
+      override _transform(
+        chunk: unknown,
+        encoding: BufferEncoding,
+        done: TransformCallback,
+      ): void {
+        super._transform(
+          chunk,
+          encoding,
+          (...args: Parameters<TransformCallback>) => {
+            order.push(`done-${chunk}`);
+            done(...args);
+          },
+        );
+      }
+    }
+
+    await pipeline(
+      Readable.from([1]),
+      new InstrumentedParallelTransform({
+        objectMode: true,
+        maxConcurrency: 16,
+        transform: (
+          chunk: number,
+          _: BufferEncoding,
+          done: TransformCallback,
+        ) => {
+          order.push(`transform-${chunk}`);
+          done(null, chunk);
+        },
+      }),
+      collect(result),
+    );
+
+    deepEqual(order, ['transform-1', 'done-1']);
+    deepEqual(result, [1]);
+  });
+
   describe('When creating a new instance in a synchronous pipeline of objects', () => {
     describe('When no error occurs in the transform or flush function', () => {
       const testCases = [
@@ -17,7 +139,7 @@ describe('Given ParallelTransform', () => {
             'When input is an empty array, it should return an empty array',
           input: [],
           transform: (
-            chunk: never,
+            chunk: number,
             _: BufferEncoding,
             done: TransformCallback,
           ) => {
@@ -108,7 +230,7 @@ describe('Given ParallelTransform', () => {
             'When input is an empty array, it should return an empty array since the transform function is never called',
           input: [],
           transform: (
-            chunk: never,
+            chunk: number,
             _: BufferEncoding,
             done: TransformCallback,
           ) => {
@@ -479,7 +601,7 @@ describe('Given ParallelTransform', () => {
             objectMode: true,
             maxConcurrency,
             transform: (
-              chunk: never,
+              chunk: number,
               bufferEncoding: BufferEncoding,
               done: TransformCallback,
             ) => {

--- a/src/parallel-transform.ts
+++ b/src/parallel-transform.ts
@@ -95,9 +95,12 @@ export class ParallelTransform extends Transform {
     }
   }
 
-  _destroy(error: Error | null, callback: (error: Error | null) => void): void {
+  _destroy(
+    error: Error | null,
+    callback: (error?: Error | null) => void,
+  ): void {
     this._rateLimiter?.destroy();
-    callback(error);
+    super._destroy(error, callback);
   }
 
   _flush(done: TransformCallback) {

--- a/src/parallel-transform.ts
+++ b/src/parallel-transform.ts
@@ -1,11 +1,14 @@
 import { Transform } from 'node:stream';
 import type { TransformCallback, TransformOptions } from 'node:stream';
 
-import { FixedWindowRateLimiter } from './rate-limiter.js';
+import {
+  FixedWindowRateLimiter,
+  type RateLimitOptions,
+} from './rate-limiter.js';
 
 export type ParallelTransformOptions = TransformOptions & {
   maxConcurrency?: number;
-  ratePerSecond?: number;
+  rateLimit?: RateLimitOptions;
 };
 
 /**
@@ -39,15 +42,15 @@ export class ParallelTransform extends Transform {
       flush = (done: TransformCallback): void => done(null),
       ...rest
     } = options;
-    const { ratePerSecond, maxConcurrency = 16, ...streamOptions } = rest;
+    const { rateLimit, maxConcurrency = 16, ...streamOptions } = rest;
     super(streamOptions);
     this.user = {
       transform,
       flush,
     };
     this._maxConcurrency = maxConcurrency;
-    this._rateLimiter = ratePerSecond
-      ? new FixedWindowRateLimiter(ratePerSecond)
+    this._rateLimiter = rateLimit
+      ? new FixedWindowRateLimiter(rateLimit)
       : undefined;
   }
 
@@ -55,8 +58,12 @@ export class ParallelTransform extends Transform {
     return this._maxConcurrency;
   }
 
-  get ratePerSecond(): number | undefined {
-    return this._rateLimiter?.ratePerSecond;
+  get rateLimit(): RateLimitOptions | undefined {
+    if (!this._rateLimiter) return undefined;
+    return {
+      maxPerWindow: this._rateLimiter.maxPerWindow,
+      windowMs: this._rateLimiter.windowMs,
+    };
   }
 
   _transform(

--- a/src/parallel-transform.ts
+++ b/src/parallel-transform.ts
@@ -99,6 +99,9 @@ export class ParallelTransform extends Transform {
     error: Error | null,
     callback: (error?: Error | null) => void,
   ): void {
+    // Pending callbacks are rate-limited user transforms that haven't
+    // started yet. Dropping them is safe: _destroy runs on error/abort
+    // paths where _flush (which waits on inflight === 0) will never run.
     this._rateLimiter?.destroy();
     super._destroy(error, callback);
   }

--- a/src/parallel-transform.ts
+++ b/src/parallel-transform.ts
@@ -99,10 +99,11 @@ export class ParallelTransform extends Transform {
     error: Error | null,
     callback: (error?: Error | null) => void,
   ): void {
-    // Pending callbacks are rate-limited user transforms that haven't
-    // started yet. Dropping them is safe: _destroy runs on error/abort
-    // paths where _flush (which waits on inflight === 0) will never run.
-    this._rateLimiter?.destroy();
+    if (this._rateLimiter) {
+      // Decrement inflight for each pending callback that will never run,
+      // keeping the counter consistent even after destroy.
+      this.inflight = Math.max(0, this.inflight - this._rateLimiter.destroy());
+    }
     super._destroy(error, callback);
   }
 

--- a/src/parallel-transform.ts
+++ b/src/parallel-transform.ts
@@ -19,7 +19,8 @@ export class ParallelTransform extends Transform {
   };
   protected readonly _maxConcurrency: number;
   protected readonly _rateLimiter: FixedWindowRateLimiter | undefined;
-  protected running: number = 0;
+  /** Counts chunks accepted into the pipeline (queued or actively processing). */
+  protected inflight: number = 0;
   protected readonly callbacks: {
     flush: TransformCallback | undefined;
     transform: TransformCallback | undefined;
@@ -63,7 +64,7 @@ export class ParallelTransform extends Transform {
     encoding: BufferEncoding,
     done: TransformCallback,
   ): void {
-    this.running++;
+    this.inflight++;
 
     const startUserTransform = () => {
       this.user.transform.call(
@@ -80,7 +81,7 @@ export class ParallelTransform extends Transform {
       startUserTransform();
     }
 
-    if (this.running < this._maxConcurrency) {
+    if (this.inflight < this._maxConcurrency) {
       done();
     } else {
       this.callbacks.transform = done;
@@ -93,7 +94,7 @@ export class ParallelTransform extends Transform {
   }
 
   _flush(done: TransformCallback) {
-    if (this.running > 0) {
+    if (this.inflight > 0) {
       // In case _flush is called before all the transforms are done
       // we need to wait for the rest of the transforms to be completed
       this.callbacks.flush = done;
@@ -104,7 +105,7 @@ export class ParallelTransform extends Transform {
 
   protected onUserTransformComplete(): TransformCallback {
     return (error?: Error | null, data?: never): void => {
-      this.running--;
+      this.inflight--;
       if (error) {
         this.emit('error', error);
         return;
@@ -119,7 +120,7 @@ export class ParallelTransform extends Transform {
         // now that we have it
         this.push(data);
       }
-      if (this.running === 0 && this.callbacks.flush) {
+      if (this.inflight === 0 && this.callbacks.flush) {
         this.user.flush.call(
           this,
           this.onUserFlushComplete(this.callbacks.flush),

--- a/src/parallel-transform.ts
+++ b/src/parallel-transform.ts
@@ -1,8 +1,11 @@
 import { Transform } from 'node:stream';
 import type { TransformCallback, TransformOptions } from 'node:stream';
 
+import { FixedWindowRateLimiter } from './rate-limiter.js';
+
 export type ParallelTransformOptions = TransformOptions & {
   maxConcurrency?: number;
+  ratePerSecond?: number;
 };
 
 /**
@@ -14,7 +17,8 @@ export class ParallelTransform extends Transform {
     transform: Exclude<TransformOptions['transform'], undefined>;
     flush: Exclude<TransformOptions['flush'], undefined>;
   };
-  protected readonly maxConcurrency: number;
+  protected readonly _maxConcurrency: number;
+  protected readonly _rateLimiter: FixedWindowRateLimiter | undefined;
   protected running: number = 0;
   protected readonly callbacks: {
     flush: TransformCallback | undefined;
@@ -24,22 +28,34 @@ export class ParallelTransform extends Transform {
     transform: undefined,
   };
 
-  constructor({
-    transform = (
-      chunk: unknown,
-      _: BufferEncoding,
-      done: TransformCallback,
-    ): void => done(null, chunk),
-    flush = (done: TransformCallback): void => done(null),
-    maxConcurrency = 16,
-    ...options
-  }: ParallelTransformOptions) {
-    super(options);
+  constructor(options: ParallelTransformOptions) {
+    const {
+      transform = (
+        chunk: unknown,
+        _: BufferEncoding,
+        done: TransformCallback,
+      ): void => done(null, chunk),
+      flush = (done: TransformCallback): void => done(null),
+      ...rest
+    } = options;
+    const { ratePerSecond, maxConcurrency = 16, ...streamOptions } = rest;
+    super(streamOptions);
     this.user = {
       transform,
       flush,
     };
-    this.maxConcurrency = maxConcurrency;
+    this._maxConcurrency = maxConcurrency;
+    this._rateLimiter = ratePerSecond
+      ? new FixedWindowRateLimiter(ratePerSecond)
+      : undefined;
+  }
+
+  get maxConcurrency(): number {
+    return this._maxConcurrency;
+  }
+
+  get ratePerSecond(): number | undefined {
+    return this._rateLimiter?.ratePerSecond;
   }
 
   _transform(
@@ -48,17 +64,32 @@ export class ParallelTransform extends Transform {
     done: TransformCallback,
   ): void {
     this.running++;
-    this.user.transform.call(
-      this,
-      chunk,
-      encoding,
-      this.onUserTransformComplete(),
-    );
-    if (this.running < this.maxConcurrency) {
+
+    const startUserTransform = () => {
+      this.user.transform.call(
+        this,
+        chunk,
+        encoding,
+        this.onUserTransformComplete(),
+      );
+    };
+
+    if (this._rateLimiter) {
+      this._rateLimiter.acquire(startUserTransform);
+    } else {
+      startUserTransform();
+    }
+
+    if (this.running < this._maxConcurrency) {
       done();
     } else {
       this.callbacks.transform = done;
     }
+  }
+
+  _destroy(error: Error | null, callback: (error: Error | null) => void): void {
+    this._rateLimiter?.destroy();
+    callback(error);
   }
 
   _flush(done: TransformCallback) {

--- a/src/queue/linked-list-queue.ts
+++ b/src/queue/linked-list-queue.ts
@@ -46,6 +46,12 @@ export class LinkedListQueue<T> extends Queue<T> {
     return this.numberOfNodes;
   }
 
+  clear(): void {
+    this.head = undefined;
+    this.tail = undefined;
+    this.numberOfNodes = 0;
+  }
+
   [Symbol.iterator](): Iterator<T> {
     let current = this.head;
     return {

--- a/src/queue/linked-list.spec.ts
+++ b/src/queue/linked-list.spec.ts
@@ -49,4 +49,19 @@ describe('Given LinkedListQueue', () => {
     equal(queue.dequeue(), 3);
     equal(queue.dequeue(), undefined);
   });
+
+  it('When clearing a non-empty queue, it should reset to empty and remain usable', () => {
+    const queue = new LinkedListQueue([1, 2, 3]);
+    equal(queue.size(), 3);
+
+    queue.clear();
+
+    equal(queue.size(), 0);
+    equal(queue.dequeue(), undefined);
+    equal(queue.peek(), undefined);
+
+    queue.enqueue(4);
+    equal(queue.size(), 1);
+    equal(queue.dequeue(), 4);
+  });
 });

--- a/src/queue/queue.ts
+++ b/src/queue/queue.ts
@@ -4,6 +4,7 @@ export abstract class Queue<T> implements Iterable<T> {
   abstract size(): number;
   abstract [Symbol.iterator](): Iterator<T>;
   abstract peek(): T | undefined;
+  abstract clear(): void;
   toArray(): T[] {
     const array: T[] = [];
     for (const value of this) {

--- a/src/rate-limiter.spec.ts
+++ b/src/rate-limiter.spec.ts
@@ -1,5 +1,5 @@
 import { deepEqual } from 'node:assert/strict';
-import { describe, it } from 'node:test';
+import { afterEach, beforeEach, describe, it } from 'node:test';
 
 import { FixedWindowRateLimiter } from './rate-limiter.js';
 
@@ -138,6 +138,169 @@ describe('Given FixedWindowRateLimiter', () => {
       // Ticking to 5000ms total should release
       context.mock.timers.tick(4000);
       deepEqual(calls, [1, 2, 3]);
+      limiter.destroy();
+    });
+  });
+
+  describe('When pending callbacks are queued across multiple windows', () => {
+    it('should process all pending callbacks even when they span several windows', context => {
+      context.mock.timers.enable({ apis: ['setInterval'] });
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 2 });
+      const calls: number[] = [];
+
+      // Fill first window (1, 2) and queue 3-7
+      for (let i = 1; i <= 7; i++) {
+        limiter.acquire(() => calls.push(i));
+      }
+
+      deepEqual(calls, [1, 2]);
+
+      context.mock.timers.tick(1000);
+      deepEqual(calls, [1, 2, 3, 4]);
+
+      context.mock.timers.tick(1000);
+      deepEqual(calls, [1, 2, 3, 4, 5, 6]);
+
+      context.mock.timers.tick(1000);
+      deepEqual(calls, [1, 2, 3, 4, 5, 6, 7]);
+
+      limiter.destroy();
+    });
+
+    it('should resume processing new acquires after pending callbacks are drained', context => {
+      context.mock.timers.enable({ apis: ['setInterval'] });
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 2 });
+      const calls: number[] = [];
+
+      limiter.acquire(() => calls.push(1));
+      limiter.acquire(() => calls.push(2));
+      limiter.acquire(() => calls.push(3));
+
+      // Drain the pending queue
+      context.mock.timers.tick(1000);
+      deepEqual(calls, [1, 2, 3]);
+
+      // Acquire again beyond the limit — new pending callbacks
+      // should still be processed on the next window reset.
+      // After onWindowReset: startsInCurrentWindow was reset to 0,
+      // then callback 3 used 1 slot (startsInCurrentWindow=1).
+      // So callback 4 takes the remaining slot, 5 and 6 are queued.
+      limiter.acquire(() => calls.push(4));
+      limiter.acquire(() => calls.push(5));
+      limiter.acquire(() => calls.push(6));
+
+      deepEqual(calls, [1, 2, 3, 4]);
+
+      context.mock.timers.tick(1000);
+      deepEqual(calls, [1, 2, 3, 4, 5, 6]);
+
+      limiter.destroy();
+    });
+  });
+
+  describe('When the timer ref state changes based on pending callbacks', () => {
+    let tick: () => void;
+    let isRefed: () => boolean;
+    const originalSetInterval = globalThis.setInterval;
+    const originalClearInterval = globalThis.clearInterval;
+
+    beforeEach(() => {
+      let callback: () => void;
+      let refed = false;
+      globalThis.setInterval = ((cb: () => void) => {
+        callback = cb;
+        refed = true;
+        return {
+          ref() {
+            refed = true;
+          },
+          unref() {
+            refed = false;
+          },
+          hasRef() {
+            return refed;
+          },
+          [Symbol.dispose]() {},
+        } as unknown as ReturnType<typeof setInterval>;
+      }) as typeof setInterval;
+      globalThis.clearInterval = (() => {
+        refed = false;
+      }) as typeof clearInterval;
+
+      tick = () => callback();
+      isRefed = () => refed;
+    });
+
+    afterEach(() => {
+      globalThis.setInterval = originalSetInterval;
+      globalThis.clearInterval = originalClearInterval;
+    });
+
+    it('should not have a ref timer before any acquire', () => {
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 2 });
+
+      deepEqual(
+        isRefed(),
+        false,
+        'Timer should not be refed before any acquire',
+      );
+
+      limiter.destroy();
+    });
+
+    it('should start the timer as unrefed when no callbacks are pending', () => {
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 2 });
+
+      limiter.acquire(() => {});
+
+      deepEqual(
+        isRefed(),
+        false,
+        'Timer should not be refed when no callbacks are pending',
+      );
+      limiter.destroy();
+    });
+
+    it('should ref the timer when a callback is queued', () => {
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 1 });
+
+      limiter.acquire(() => {});
+      deepEqual(
+        isRefed(),
+        false,
+        'Timer should not be refed when no callbacks are pending',
+      );
+
+      limiter.acquire(() => {});
+      deepEqual(
+        isRefed(),
+        true,
+        'Timer should be refed when a callback is queued',
+      );
+
+      limiter.destroy();
+    });
+
+    it('should unref the timer after all pending callbacks are drained', () => {
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 2 });
+
+      limiter.acquire(() => {});
+      limiter.acquire(() => {});
+      limiter.acquire(() => {});
+
+      deepEqual(
+        isRefed(),
+        true,
+        'Timer should be refed when a callback is queued',
+      );
+
+      tick();
+
+      deepEqual(
+        isRefed(),
+        false,
+        'Timer should not be refed when all pending callbacks are drained',
+      );
       limiter.destroy();
     });
   });

--- a/src/rate-limiter.spec.ts
+++ b/src/rate-limiter.spec.ts
@@ -5,9 +5,9 @@ import { FixedWindowRateLimiter } from './rate-limiter.js';
 
 describe('Given FixedWindowRateLimiter', () => {
   describe('When acquiring within the rate limit', () => {
-    it('should allow up to ratePerSecond calls immediately', context => {
+    it('should allow up to maxPerWindow calls immediately', context => {
       context.mock.timers.enable({ apis: ['setInterval'] });
-      const limiter = new FixedWindowRateLimiter(3);
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 3 });
       const calls: number[] = [];
 
       limiter.acquire(() => calls.push(1));
@@ -22,7 +22,7 @@ describe('Given FixedWindowRateLimiter', () => {
   describe('When acquiring beyond the rate limit', () => {
     it('should queue the callback exceeding the rate', context => {
       context.mock.timers.enable({ apis: ['setInterval'] });
-      const limiter = new FixedWindowRateLimiter(2);
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 2 });
       const calls: number[] = [];
 
       limiter.acquire(() => calls.push(1));
@@ -36,7 +36,7 @@ describe('Given FixedWindowRateLimiter', () => {
 
     it('should release queued callbacks on window reset', context => {
       context.mock.timers.enable({ apis: ['setInterval'] });
-      const limiter = new FixedWindowRateLimiter(2);
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 2 });
       const calls: number[] = [];
 
       limiter.acquire(() => calls.push(1));
@@ -51,9 +51,9 @@ describe('Given FixedWindowRateLimiter', () => {
       limiter.destroy();
     });
 
-    it('should release at most ratePerSecond callbacks per window', context => {
+    it('should release at most maxPerWindow callbacks per window', context => {
       context.mock.timers.enable({ apis: ['setInterval'] });
-      const limiter = new FixedWindowRateLimiter(2);
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 2 });
       const calls: number[] = [];
 
       for (let i = 1; i <= 6; i++) {
@@ -74,7 +74,7 @@ describe('Given FixedWindowRateLimiter', () => {
   describe('When destroying the rate limiter', () => {
     it('should clear pending callbacks and stop the timer', context => {
       context.mock.timers.enable({ apis: ['setInterval'] });
-      const limiter = new FixedWindowRateLimiter(1);
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 1 });
       const calls: number[] = [];
 
       limiter.acquire(() => calls.push(1));
@@ -92,7 +92,7 @@ describe('Given FixedWindowRateLimiter', () => {
   describe('When all pending callbacks are released', () => {
     it('should stop the timer automatically', context => {
       context.mock.timers.enable({ apis: ['setInterval'] });
-      const limiter = new FixedWindowRateLimiter(2);
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 2 });
       const calls: number[] = [];
 
       limiter.acquire(() => calls.push(1));
@@ -116,10 +116,36 @@ describe('Given FixedWindowRateLimiter', () => {
     });
   });
 
+  describe('When using a custom window duration', () => {
+    it('should use the specified windowMs for the interval', context => {
+      context.mock.timers.enable({ apis: ['setInterval'] });
+      const limiter = new FixedWindowRateLimiter({
+        maxPerWindow: 2,
+        windowMs: 5_000,
+      });
+      const calls: number[] = [];
+
+      limiter.acquire(() => calls.push(1));
+      limiter.acquire(() => calls.push(2));
+      limiter.acquire(() => calls.push(3));
+
+      deepEqual(calls, [1, 2]);
+
+      // Ticking 1000ms should NOT release (window is 5000ms)
+      context.mock.timers.tick(1000);
+      deepEqual(calls, [1, 2]);
+
+      // Ticking to 5000ms total should release
+      context.mock.timers.tick(4000);
+      deepEqual(calls, [1, 2, 3]);
+      limiter.destroy();
+    });
+  });
+
   describe('When acquiring after a window reset with no pending callbacks', () => {
     it('should allow a full burst in the new window', context => {
       context.mock.timers.enable({ apis: ['setInterval'] });
-      const limiter = new FixedWindowRateLimiter(2);
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 2 });
       const calls: number[] = [];
 
       limiter.acquire(() => calls.push(1));

--- a/src/rate-limiter.spec.ts
+++ b/src/rate-limiter.spec.ts
@@ -305,6 +305,161 @@ describe('Given FixedWindowRateLimiter', () => {
     });
   });
 
+  describe('When window boundaries are preserved after pending drain', () => {
+    let tick: () => void;
+    let isRefed: () => boolean;
+    let timerCleared: boolean;
+    const originalSetInterval = globalThis.setInterval;
+    const originalClearInterval = globalThis.clearInterval;
+
+    beforeEach(() => {
+      let callback: () => void;
+      let refed = false;
+      timerCleared = false;
+      globalThis.setInterval = ((cb: () => void) => {
+        callback = cb;
+        refed = true;
+        timerCleared = false;
+        return {
+          ref() {
+            refed = true;
+          },
+          unref() {
+            refed = false;
+          },
+          hasRef() {
+            return refed;
+          },
+          [Symbol.dispose]() {},
+        } as unknown as ReturnType<typeof setInterval>;
+      }) as typeof setInterval;
+      globalThis.clearInterval = (() => {
+        refed = false;
+        timerCleared = true;
+      }) as typeof clearInterval;
+
+      tick = () => callback();
+      isRefed = () => refed;
+    });
+
+    afterEach(() => {
+      globalThis.setInterval = originalSetInterval;
+      globalThis.clearInterval = originalClearInterval;
+    });
+
+    it('should keep the timer alive (unrefed) after draining pending callbacks', () => {
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 2 });
+
+      limiter.acquire(() => {});
+      limiter.acquire(() => {});
+      limiter.acquire(() => {});
+
+      deepEqual(isRefed(), true, 'Timer should be refed with pending');
+
+      // Window reset drains the single pending callback
+      tick();
+
+      deepEqual(
+        timerCleared,
+        false,
+        'Timer should NOT be cleared after draining — it stays alive for one more tick',
+      );
+      deepEqual(
+        isRefed(),
+        false,
+        'Timer should be unrefed after draining so it does not block process exit',
+      );
+
+      limiter.destroy();
+    });
+
+    it('should clear the timer on the tick AFTER all pending are drained', () => {
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 2 });
+
+      limiter.acquire(() => {});
+      limiter.acquire(() => {});
+      limiter.acquire(() => {});
+
+      // First tick: drains pending, timer stays alive (unrefed)
+      tick();
+      deepEqual(timerCleared, false);
+
+      // Second tick: no pending → timer cleared
+      tick();
+      deepEqual(
+        timerCleared,
+        true,
+        'Timer should be cleared on the next tick when no pending callbacks remain',
+      );
+
+      limiter.destroy();
+    });
+
+    it('should count new acquires against the current window after drain', () => {
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 3 });
+      const calls: number[] = [];
+
+      // Fill window: 3 immediate, 1 pending
+      limiter.acquire(() => calls.push(1));
+      limiter.acquire(() => calls.push(2));
+      limiter.acquire(() => calls.push(3));
+      limiter.acquire(() => calls.push(4));
+
+      deepEqual(calls, [1, 2, 3]);
+
+      // Window reset: drains callback 4 (startsInCurrentWindow=1).
+      // Timer stays alive (unrefed).
+      tick();
+      deepEqual(calls, [1, 2, 3, 4]);
+
+      // Acquire 2 more in the SAME window (slots left: 3-1=2).
+      // Because the timer was NOT cleared, these count against the
+      // current window rather than starting a new one.
+      limiter.acquire(() => calls.push(5));
+      limiter.acquire(() => calls.push(6));
+      deepEqual(calls, [1, 2, 3, 4, 5, 6]);
+
+      // Window is now full (startsInCurrentWindow=3), next acquire is queued
+      limiter.acquire(() => calls.push(7));
+      deepEqual(
+        calls,
+        [1, 2, 3, 4, 5, 6],
+        'Callback 7 should be queued — window budget exhausted',
+      );
+
+      // Next tick releases it
+      tick();
+      deepEqual(calls, [1, 2, 3, 4, 5, 6, 7]);
+
+      limiter.destroy();
+    });
+
+    it('should re-ref the timer when new pending callbacks arrive after drain', () => {
+      const limiter = new FixedWindowRateLimiter({ maxPerWindow: 1 });
+
+      limiter.acquire(() => {});
+      limiter.acquire(() => {});
+
+      deepEqual(isRefed(), true);
+
+      // Drain: timer stays alive, unrefed
+      tick();
+      deepEqual(isRefed(), false);
+      deepEqual(timerCleared, false);
+
+      // New acquire fills the window (startsInCurrentWindow=1 after
+      // reset), then another queues → timer re-refed
+      limiter.acquire(() => {});
+      deepEqual(
+        isRefed(),
+        true,
+        'Timer should be re-refed when new pending callbacks arrive',
+      );
+
+      limiter.destroy();
+    });
+  });
+
   describe('When acquiring after a window reset with no pending callbacks', () => {
     it('should allow a full burst in the new window', context => {
       context.mock.timers.enable({ apis: ['setInterval'] });

--- a/src/rate-limiter.spec.ts
+++ b/src/rate-limiter.spec.ts
@@ -1,0 +1,139 @@
+import { deepEqual } from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { FixedWindowRateLimiter } from './rate-limiter.js';
+
+describe('Given FixedWindowRateLimiter', () => {
+  describe('When acquiring within the rate limit', () => {
+    it('should allow up to ratePerSecond calls immediately', context => {
+      context.mock.timers.enable({ apis: ['setInterval'] });
+      const limiter = new FixedWindowRateLimiter(3);
+      const calls: number[] = [];
+
+      limiter.acquire(() => calls.push(1));
+      limiter.acquire(() => calls.push(2));
+      limiter.acquire(() => calls.push(3));
+
+      deepEqual(calls, [1, 2, 3]);
+      limiter.destroy();
+    });
+  });
+
+  describe('When acquiring beyond the rate limit', () => {
+    it('should queue the callback exceeding the rate', context => {
+      context.mock.timers.enable({ apis: ['setInterval'] });
+      const limiter = new FixedWindowRateLimiter(2);
+      const calls: number[] = [];
+
+      limiter.acquire(() => calls.push(1));
+      limiter.acquire(() => calls.push(2));
+      limiter.acquire(() => calls.push(3));
+      limiter.acquire(() => calls.push(4));
+
+      deepEqual(calls, [1, 2]);
+      limiter.destroy();
+    });
+
+    it('should release queued callbacks on window reset', context => {
+      context.mock.timers.enable({ apis: ['setInterval'] });
+      const limiter = new FixedWindowRateLimiter(2);
+      const calls: number[] = [];
+
+      limiter.acquire(() => calls.push(1));
+      limiter.acquire(() => calls.push(2));
+      limiter.acquire(() => calls.push(3));
+      limiter.acquire(() => calls.push(4));
+
+      deepEqual(calls, [1, 2]);
+
+      context.mock.timers.tick(1000);
+      deepEqual(calls, [1, 2, 3, 4]);
+      limiter.destroy();
+    });
+
+    it('should release at most ratePerSecond callbacks per window', context => {
+      context.mock.timers.enable({ apis: ['setInterval'] });
+      const limiter = new FixedWindowRateLimiter(2);
+      const calls: number[] = [];
+
+      for (let i = 1; i <= 6; i++) {
+        limiter.acquire(() => calls.push(i));
+      }
+
+      deepEqual(calls, [1, 2]);
+
+      context.mock.timers.tick(1000);
+      deepEqual(calls, [1, 2, 3, 4]);
+
+      context.mock.timers.tick(1000);
+      deepEqual(calls, [1, 2, 3, 4, 5, 6]);
+      limiter.destroy();
+    });
+  });
+
+  describe('When destroying the rate limiter', () => {
+    it('should clear pending callbacks and stop the timer', context => {
+      context.mock.timers.enable({ apis: ['setInterval'] });
+      const limiter = new FixedWindowRateLimiter(1);
+      const calls: number[] = [];
+
+      limiter.acquire(() => calls.push(1));
+      limiter.acquire(() => calls.push(2));
+
+      deepEqual(calls, [1]);
+
+      limiter.destroy();
+
+      context.mock.timers.tick(1000);
+      deepEqual(calls, [1]);
+    });
+  });
+
+  describe('When all pending callbacks are released', () => {
+    it('should stop the timer automatically', context => {
+      context.mock.timers.enable({ apis: ['setInterval'] });
+      const limiter = new FixedWindowRateLimiter(2);
+      const calls: number[] = [];
+
+      limiter.acquire(() => calls.push(1));
+      limiter.acquire(() => calls.push(2));
+      limiter.acquire(() => calls.push(3));
+
+      context.mock.timers.tick(1000);
+      deepEqual(calls, [1, 2, 3]);
+
+      // Window released 1 callback (3), so startsInCurrentWindow=1.
+      // Acquiring 4 makes it 2 (at limit), so 5 and 6 are queued.
+      limiter.acquire(() => calls.push(4));
+      limiter.acquire(() => calls.push(5));
+      limiter.acquire(() => calls.push(6));
+
+      deepEqual(calls, [1, 2, 3, 4]);
+
+      context.mock.timers.tick(1000);
+      deepEqual(calls, [1, 2, 3, 4, 5, 6]);
+      limiter.destroy();
+    });
+  });
+
+  describe('When acquiring after a window reset with no pending callbacks', () => {
+    it('should allow a full burst in the new window', context => {
+      context.mock.timers.enable({ apis: ['setInterval'] });
+      const limiter = new FixedWindowRateLimiter(2);
+      const calls: number[] = [];
+
+      limiter.acquire(() => calls.push(1));
+      limiter.acquire(() => calls.push(2));
+
+      // Tick past the window
+      context.mock.timers.tick(1000);
+
+      // New burst in a fresh window
+      limiter.acquire(() => calls.push(3));
+      limiter.acquire(() => calls.push(4));
+
+      deepEqual(calls, [1, 2, 3, 4]);
+      limiter.destroy();
+    });
+  });
+});

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -1,14 +1,24 @@
 import { LinkedListQueue } from './queue/linked-list-queue.js';
 
+export type RateLimitOptions = {
+  maxPerWindow: number;
+  windowMs?: number;
+};
+
 export class FixedWindowRateLimiter {
   private startsInCurrentWindow: number = 0;
   private readonly pendingCallbacks = new LinkedListQueue<() => void>();
   private timer: ReturnType<typeof setInterval> | undefined = undefined;
+  readonly maxPerWindow: number;
+  readonly windowMs: number;
 
-  constructor(readonly ratePerSecond: number) {}
+  constructor({ maxPerWindow, windowMs = 1_000 }: RateLimitOptions) {
+    this.maxPerWindow = maxPerWindow;
+    this.windowMs = windowMs;
+  }
 
   acquire(onAllowed: () => void): void {
-    if (this.startsInCurrentWindow < this.ratePerSecond) {
+    if (this.startsInCurrentWindow < this.maxPerWindow) {
       this.startsInCurrentWindow++;
       this.ensureTimerRunning();
       onAllowed();
@@ -30,7 +40,7 @@ export class FixedWindowRateLimiter {
     if (this.timer !== undefined) return;
     this.timer = setInterval(() => {
       this.onWindowReset();
-    }, 1_000);
+    }, this.windowMs);
     this.timer.unref();
   }
 
@@ -38,7 +48,7 @@ export class FixedWindowRateLimiter {
     this.startsInCurrentWindow = 0;
     while (
       this.pendingCallbacks.size() > 0 &&
-      this.startsInCurrentWindow < this.ratePerSecond
+      this.startsInCurrentWindow < this.maxPerWindow
     ) {
       this.startsInCurrentWindow++;
       const cb = this.pendingCallbacks.dequeue()!;

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -56,6 +56,18 @@ export class FixedWindowRateLimiter {
   }
 
   private onWindowReset(): void {
+    // Clear the timer BEFORE resetting the counter. If we cleared after
+    // the reset, a new acquire arriving between the reset and the next
+    // interval would start a fresh timer — shifting the window boundary.
+    // By clearing first (while startsInCurrentWindow still reflects the
+    // previous window's usage), then resetting, any acquire that arrives
+    // before a new interval starts will count against the freshly-reset
+    // window. The timer naturally clears itself one tick after the last
+    // pending callback is drained, preserving consistent window boundaries.
+    if (this.pendingCallbacks.size() === 0) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
     this.startsInCurrentWindow = 0;
     while (
       this.pendingCallbacks.size() > 0 &&
@@ -65,9 +77,12 @@ export class FixedWindowRateLimiter {
       const cb = this.pendingCallbacks.dequeue()!;
       cb();
     }
-    if (this.pendingCallbacks.size() === 0) {
-      clearInterval(this.timer);
-      this.timer = undefined;
+    // Unref AFTER draining: if all pending callbacks were released in the
+    // loop above, the timer is no longer needed to keep the process alive
+    // but must stay running to fire one more tick for a clean shutdown
+    // (the clear check at the top of the next invocation).
+    if (this.timer !== undefined && this.pendingCallbacks.size() === 0) {
+      this.timer.unref();
     }
   }
 }

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -28,12 +28,14 @@ export class FixedWindowRateLimiter {
     }
   }
 
-  destroy(): void {
+  destroy(): number {
     if (this.timer !== undefined) {
       clearInterval(this.timer);
       this.timer = undefined;
     }
+    const dropped = this.pendingCallbacks.size();
     this.pendingCallbacks.clear();
+    return dropped;
   }
 
   private ensureTimerRunning(): void {

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -1,6 +1,8 @@
+import { LinkedListQueue } from './queue/linked-list-queue.js';
+
 export class FixedWindowRateLimiter {
   private startsInCurrentWindow: number = 0;
-  private readonly pendingCallbacks: (() => void)[] = [];
+  private readonly pendingCallbacks = new LinkedListQueue<() => void>();
   private timer: ReturnType<typeof setInterval> | undefined = undefined;
 
   constructor(readonly ratePerSecond: number) {}
@@ -11,7 +13,7 @@ export class FixedWindowRateLimiter {
       this.ensureTimerRunning();
       onAllowed();
     } else {
-      this.pendingCallbacks.push(onAllowed);
+      this.pendingCallbacks.enqueue(onAllowed);
       this.ensureTimerRunning();
     }
   }
@@ -21,7 +23,7 @@ export class FixedWindowRateLimiter {
       clearInterval(this.timer);
       this.timer = undefined;
     }
-    this.pendingCallbacks.length = 0;
+    this.pendingCallbacks.clear();
   }
 
   private ensureTimerRunning(): void {
@@ -35,14 +37,14 @@ export class FixedWindowRateLimiter {
   private onWindowReset(): void {
     this.startsInCurrentWindow = 0;
     while (
-      this.pendingCallbacks.length > 0 &&
+      this.pendingCallbacks.size() > 0 &&
       this.startsInCurrentWindow < this.ratePerSecond
     ) {
       this.startsInCurrentWindow++;
-      const cb = this.pendingCallbacks.shift()!;
+      const cb = this.pendingCallbacks.dequeue()!;
       cb();
     }
-    if (this.pendingCallbacks.length === 0) {
+    if (this.pendingCallbacks.size() === 0) {
       clearInterval(this.timer);
       this.timer = undefined;
     }

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -37,11 +37,20 @@ export class FixedWindowRateLimiter {
   }
 
   private ensureTimerRunning(): void {
+    if (
+      this.timer !== undefined &&
+      !this.timer.hasRef() &&
+      this.pendingCallbacks.size() !== 0
+    ) {
+      this.timer.ref();
+    }
     if (this.timer !== undefined) return;
     this.timer = setInterval(() => {
       this.onWindowReset();
     }, this.windowMs);
-    this.timer.unref();
+    if (this.pendingCallbacks.size() === 0) {
+      this.timer.unref();
+    }
   }
 
   private onWindowReset(): void {

--- a/src/rate-limiter.ts
+++ b/src/rate-limiter.ts
@@ -1,0 +1,50 @@
+export class FixedWindowRateLimiter {
+  private startsInCurrentWindow: number = 0;
+  private readonly pendingCallbacks: (() => void)[] = [];
+  private timer: ReturnType<typeof setInterval> | undefined = undefined;
+
+  constructor(readonly ratePerSecond: number) {}
+
+  acquire(onAllowed: () => void): void {
+    if (this.startsInCurrentWindow < this.ratePerSecond) {
+      this.startsInCurrentWindow++;
+      this.ensureTimerRunning();
+      onAllowed();
+    } else {
+      this.pendingCallbacks.push(onAllowed);
+      this.ensureTimerRunning();
+    }
+  }
+
+  destroy(): void {
+    if (this.timer !== undefined) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+    this.pendingCallbacks.length = 0;
+  }
+
+  private ensureTimerRunning(): void {
+    if (this.timer !== undefined) return;
+    this.timer = setInterval(() => {
+      this.onWindowReset();
+    }, 1_000);
+    this.timer.unref();
+  }
+
+  private onWindowReset(): void {
+    this.startsInCurrentWindow = 0;
+    while (
+      this.pendingCallbacks.length > 0 &&
+      this.startsInCurrentWindow < this.ratePerSecond
+    ) {
+      this.startsInCurrentWindow++;
+      const cb = this.pendingCallbacks.shift()!;
+      cb();
+    }
+    if (this.pendingCallbacks.length === 0) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+}

--- a/src/utils/async-identity.ts
+++ b/src/utils/async-identity.ts
@@ -1,13 +1,13 @@
 import type { TransformCallback } from 'node:stream';
 
-export class AsyncIdentity {
+export class AsyncIdentity<T> {
   private transformCalls: number = 0;
   private concurrentCalls: number = 0;
   private maxConcurrentCalls: number = 0;
   private timeout: number | undefined = undefined;
   constructor(private readonly timeouts: number[]) {}
 
-  transform(chunk: never, _: BufferEncoding, done: TransformCallback): void {
+  transform(chunk: T, _: BufferEncoding, done: TransformCallback): void {
     this.concurrentCalls++;
     this.maxConcurrentCalls = Math.max(
       this.concurrentCalls,


### PR DESCRIPTION
## Summary

- Introduce `FixedWindowRateLimiter` — a fixed-window rate limiter that caps how many chunk transforms can start per time window, queuing excess requests until the next window opens
- Add `rateLimit` option (`{ maxPerWindow, windowMs? }`) to `ParallelTransform` and `OrderedParallelTransform`, working alongside the existing `maxConcurrency` option
- Export `RateLimitOptions` type from the public API
- Properly handle stream destruction: pending rate-limiter callbacks are dropped and the inflight counter stays consistent
- Timer is `unref`'d when no callbacks are pending so it doesn't keep the process alive unnecessarily
- Window boundaries are preserved by deferring timer cleanup until after pending callbacks are drained

## Details

### Rate limiter (`src/rate-limiter.ts`)
- `FixedWindowRateLimiter` uses a `LinkedListQueue` for pending callbacks
- `acquire(cb)` either runs the callback immediately (if under the window cap) or queues it
- On each window tick, the counter resets and queued callbacks are drained up to `maxPerWindow`
- `destroy()` clears the timer and returns the count of dropped pending callbacks

### Integration with `ParallelTransform`
- `_transform` wraps the user transform in a `rateLimiter.acquire()` call when rate limiting is configured
- `_destroy` calls `rateLimiter.destroy()` and adjusts the inflight count for dropped callbacks
- Renamed internal `running` → `inflight` to better reflect that chunks may be queued in the rate limiter
- `maxConcurrency` is now exposed as a getter (backing field `_maxConcurrency`)
- Added `rateLimit` getter that returns current config

### Tests
- 483 lines of dedicated rate limiter tests (`src/rate-limiter.spec.ts`) covering: basic throttling, queuing, multi-window draining, destroy semantics, timer ref/unref behavior, and window boundary preservation
- Integration tests in `parallel-transform.spec.ts` and `ordered-parallel-transform.spec.ts` verifying rate limiting works end-to-end with both stream variants
- Factory function tests confirming `rateLimit` option is passed through

### Other changes
- Added `test:watch` script to `package.json`
- Made `AsyncIdentity` test utility generic
- Added `clear()` method to `LinkedListQueue` / `Queue`
- Added examples for rate-limited usage in `src/examples/`
- Updated `README.md` with rate limiting documentation

## Test plan
- [x] All existing tests pass
- [x] Rate limiter unit tests cover core behavior, edge cases, and cleanup
- [x] Integration tests verify rate limiting with `ParallelTransform` and `OrderedParallelTransform`
- [x] Factory tests confirm option passthrough
